### PR TITLE
Confirm support for Django 4.2 in `0.9.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click==7.0
-Django==3.0.7
+Django==4.2.11
 djangorestframework==3.9.4
 Jinja2==2.11.1
 livereload==2.6.1
@@ -12,6 +12,6 @@ pymdown-extensions==6.3
 pytz==2018.3
 PyYAML==5.3
 six==1.14.0
-sqlparse==0.3.0
+sqlparse==0.3.1
 tornado==6.0.3
 urlman==1.2.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -120,3 +120,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = "/static/"
+
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/tests/testapp/tests/test_user_account.py
+++ b/tests/testapp/tests/test_user_account.py
@@ -134,5 +134,5 @@ class UserAccountTestCase(TestCase):
         value = UserAccount.objects.all().delete()
 
         self.assertEqual(
-            value, (1, {"testapp.Locale_users": 0, "testapp.UserAccount": 1})
+            value, (1, {"testapp.UserAccount": 1})
         )


### PR DESCRIPTION
## Changes
* Bumps `django` version in `requirements.txt` for testing
* Bumps `sqlparse` version in `requirements.txt` for testing (compatibility)
* Fixes unit test related to change in https://github.com/django/django/pull/12747

## Notes
The following was run with these changes to confirm compatibility:
```console
$ pyenv local 3.9
$ python -m venv venv
$ source venv/bin/activate
$ pip install -r requirements.txt
$ python ./manage.py test
```