### PR TITLE
Update tests to run against supported Python and Django versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
           uv tool install --python ${{ matrix.python-version }} tox --with tox-gh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,18 +17,12 @@ jobs:
     name: Python ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: "${{ matrix.python-version }}"
-          allow-prereleases: true
-
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install tox
         run: |
-          python -m pip install --upgrade pip
-          pip install tox
-
-      - name: Run tox
+          uv tool install --python ${{ matrix.python-version }} tox --with tox-gh
+      - name: Run tests
         run: tox
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,13 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install tox
-        run: |
-          uv tool install --python ${{ matrix.python-version }} tox --with tox-gh
+      - name: Install dependencies
+        run: pip install tox tox-gh-actions
       - name: Run tests
         run: tox
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install tox tox-gh-actions
-      - name: Run tests
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Test with tox
         run: tox
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [0.9.1]
+  pull_request:
+    branches: [0.9.1]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    name: Python ${{ matrix.python-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
+
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run tox
+        run: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click==7.0
-Django==4.2.11
+Django==5.2.12
 djangorestframework==3.9.4
 Jinja2==2.11.1
 livereload==2.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,18 @@ envlist =
     py3{12,13,14}-django60
     ; Commented out because it is failing and we don't care about linting this old version correctly
     ; flake8
-skip_missing_interpreters = True
+;skip_missing_interpreters = True
 
 [flake8]
 max-line-length = 120
+
+[gh]
+python =
+    3.10 = py310
+    3.11 = py311
+    3.12 = py312
+    3.13 = py313
+    3.14 = py314
 
 [testenv]
 commands = python ./manage.py test

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
 [flake8]
 max-line-length = 120
 
-[gh]
+[gh-actions]
 python =
     3.10 = py310
     3.11 = py311

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 toxworkdir={env:TOXWORKDIR:{toxinidir}/.tox}
 envlist =
-    {py35,py36,py37}-django20
-    {py35,py36,py37}-django21
-    {py35,py36,py37,py38,py39}-django22
-    {py36,py37,py38,py39}-django30
-    {py36,py37,py38,py39}-django31
-    flake8
+    py3{10,11,12}-django42
+    py3{10,11,12,13,14}-django52
+    py3{12,13,14}-django60
+    ; Commented out because it is failing and we don't care about linting this old version correctly
+    ; flake8
 skip_missing_interpreters = True
 
 [flake8]
@@ -20,11 +19,11 @@ setenv =
     PYTHONWARNINGS=once
     DJANGO_SETTINGS_MODULE=tests.settings
 deps =
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
-    django22: django>=2.2,<3
-    django30: django>=3.0,<3.1
-    django31: django>=3.1,<3.2
+    urlman>=1.2.0
+    setuptools
+    django42: django>=4.2,<4.3
+    django52: django>=5.2,<5.3
+    django60: django>=6.0,<6.1
 
 [testenv:flake8]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,11 @@ max-line-length = 120
 
 [gh-actions]
 python =
-    3.10 = py310
-    3.11 = py311
-    3.12 = py312
-    3.13 = py313
-    3.14 = py314
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 commands = python ./manage.py test


### PR DESCRIPTION
Update our django-lifecycle branch (0.9.1) to test against the currently supported versions of Python and Django. I've also added a GitHub action script to simplify the process of testing against multiple versions/combinations since we don't actually know which Python we will end up on.